### PR TITLE
Resolve issue with Convert-PemToPfx

### DIFF
--- a/PSPKI/Client/Convert-PemToPfx.ps1
+++ b/PSPKI/Client/Convert-PemToPfx.ps1
@@ -1,4 +1,4 @@
-﻿function Convert-PemToPfx {
+function Convert-PemToPfx {
 <#
 .ExternalHelp PSPKI.Help.xml
 #>
@@ -87,7 +87,7 @@
         $rsa.ImportCspBlob($PrivateKey)
         if ($PSVersionTable.PSEdition -eq "Core") {
             Add-Type -AssemblyName "System.Security.Cryptography.X509Certificates"
-            $script:Cert = [Security.Cryptography.X509Certificates.RSACertificateExtensions]::CopyWithPrivateKey($_Cert.RawData, $rsa)
+            $script:Cert = [Security.Cryptography.X509Certificates.RSACertificateExtensions]::CopyWithPrivateKey($Cert.RawData, $rsa)
 
         } else {
             $script:Cert.PrivateKey = $rsa
@@ -181,7 +181,7 @@
                 $Password = Read-Host -Prompt "Enter PFX password" -AsSecureString
             }
             $pfxBytes = $Cert.Export("pfx", $Password)
-            if ($PsIsCore) {
+            if ($PSVersionTable.PSEdition -eq "Core") {
                 Set-Content -Path $OutputPath -Value $pfxBytes -AsByteStream
             } else {
                 Set-Content -Path $OutputPath -Value $pfxBytes -Encoding Byte

--- a/PSPKI/Client/Convert-PemToPfx.ps1
+++ b/PSPKI/Client/Convert-PemToPfx.ps1
@@ -6,14 +6,29 @@
 [CmdletBinding()]
     param(
         [Parameter(Mandatory = $true, Position = 0)]
-        [string]$InputPath,
-        [string]$KeyPath,
-        [string]$OutputPath,
-        [Security.Cryptography.X509Certificates.X509KeySpecFlags]$KeySpec = "AT_KEYEXCHANGE",
-        [Security.SecureString]$Password,
-        [string]$ProviderName = "Microsoft Enhanced RSA and AES Cryptographic Provider",
-        [Security.Cryptography.X509Certificates.StoreLocation]$StoreLocation = "CurrentUser",
-        [switch]$Install
+        [string]
+        $InputPath,
+        [Parameter()]
+        [string]
+        $KeyPath,
+        [Parameter()]
+        [string]
+        $OutputPath,
+        [Parameter()]
+        [Security.Cryptography.X509Certificates.X509KeySpecFlags]
+        $KeySpec = "AT_KEYEXCHANGE",
+        [Parameter()]
+        [Security.SecureString]
+        $Password,
+        [Parameter()]
+        [string]
+        $ProviderName = "Microsoft Enhanced RSA and AES Cryptographic Provider",
+        [Parameter()]
+        [Security.Cryptography.X509Certificates.StoreLocation]
+        $StoreLocation = "CurrentUser",
+        [Parameter()]
+        [switch]
+        $Install
     )
     if ($PSBoundParameters.Verbose) {$VerbosePreference = "continue"}
     if ($PSBoundParameters.Debug) {


### PR DESCRIPTION
ConvertPemToPfx failed in PSCore with 
`
Line |
  71 |  …      $rsa = New-Object Security.Cryptography.RSACryptoServiceProvider …
     |                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     | Exception calling ".ctor" with "1" argument(s): "Bad Key."
`

These changes resolve the issue