### PR TITLE
Addressed exception handling in Revoke-Certificate

### DIFF
--- a/PSPKI/Server/Revoke-Certificate.ps1
+++ b/PSPKI/Server/Revoke-Certificate.ps1
@@ -49,7 +49,11 @@ function Revoke-Certificate {
             New-Object SysadminsLV.PKI.Utils.ServiceOperationResult 0,
                 "Successfully revoked certificate with ID=$($Request.RequestID) and reason: '$Reason'"
         } catch {
-            New-Object SysadminsLV.PKI.Utils.ServiceOperationResult $($_.Exception.InnerException.InnerException.HResult)
+            if ($_.Exception.InnerException.InnerException.HResult -eq $null) {
+                New-Object SysadminsLV.PKI.Utils.ServiceOperationResult $($_.Exception.InnerException.InnerException.HResult)
+            } else {
+                New-Object SysadminsLV.PKI.Utils.ServiceOperationResult 0x80004005, $($_.Exception.InnerException.InnerException.Message)
+            }
         }
     }
     end {


### PR DESCRIPTION
Should address #210. It seems that sometimes inner exception doesn't have HResult, thus cannot construct return value. Coerce such exceptions to use HRESULT=0x80004005 (Unspecified Error)