### PR TITLE
Added better "target" description when using Register/Unregister-ObjectIdentifier

### DIFF
--- a/PSPKI/Client/Register-ObjectIdentifier.ps1
+++ b/PSPKI/Client/Register-ObjectIdentifier.ps1
@@ -25,8 +25,18 @@ function Register-ObjectIdentifier {
         "ApplicationPolicy" {[Security.Cryptography.OidGroup]::EnhancedKeyUsage}
         "IssuancePolicy" {[Security.Cryptography.OidGroup]::Policy}
     }
+
+    $target = if ($UseActiveDirectory) {
+        try {
+            [System.DirectoryServices.ActiveDirectory.Domain]::GetComputerDomain().Forest.Name
+        } catch {
+            $Env:COMPUTERNAME
+        }
+    } else {
+        $Env:COMPUTERNAME
+    }
     if ($Force -or $PSCmdlet.ShouldProcess(
-        $Env:COMPUTERNAME,
+        $target,
         "Register object identifier with name: '$FriendlyName' and value: '$Value'"
     )) {
         [SysadminsLV.PKI.Cryptography.Oid2]::Register($Value,$FriendlyName,$Group,$UseActiveDirectory,$LocaleId,$CPSLocation)

--- a/PSPKI/Client/Unregister-ObjectIdentifier.ps1
+++ b/PSPKI/Client/Unregister-ObjectIdentifier.ps1
@@ -13,8 +13,17 @@
         [switch]$UseActiveDirectory,
         [switch]$Force
     )
+    $target = if ($UseActiveDirectory) {
+        try {
+            [System.DirectoryServices.ActiveDirectory.Domain]::GetComputerDomain().Forest.Name
+        } catch {
+            $Env:COMPUTERNAME
+        }
+    } else {
+        $Env:COMPUTERNAME
+    }
     if ($Force -or $PSCmdlet.ShouldProcess(
-        $Env:COMPUTERNAME,
+        $target,
         "Unregister object identifier with name: '$($Value.FriendlyName)' and value: '$($Value.Value)'"
     )) {
         $retValue = [SysadminsLV.PKI.Cryptography.Oid2]::Unregister($Value.Value,$OidGroup,$UseActiveDirectory)


### PR DESCRIPTION
Addressed #223

If `-UseActiveDirectory` is `$false`, then local machine name is displayed in `target` field. If `-UseActiveDirectory` is `$true`, then current forest name is displayed.

It doesn't matter to which domain user belongs, changes to configuration naming context are written to forest root domain. OIDs are forest-wide resources, so we don't care where user belongs to as long as it can write to configuration naming context.