### PR TITLE
Added an option to include Attributes and Extensions tables when querying ADCS DB

### DIFF
--- a/PSPKI/Server/Get-AdcsDatabaseRow.ps1
+++ b/PSPKI/Server/Get-AdcsDatabaseRow.ps1
@@ -16,7 +16,9 @@
         [int]$PageSize = [int]::MaxValue,
         [Alias("Properties", "IncludeProperty", "IncludeProperties", "IncludedProperty", "IncludedProperties")]
         [String[]]$Property,
-        [String[]]$Filter
+        [String[]]$Filter,
+        [switch]$IncludeAttribute,
+        [switch]$IncludeExtension
     )
     begin {
         Assert-CommandRequirement $PREREQ_RSAT -ErrorAction Stop
@@ -58,22 +60,28 @@
                     $RowID | ForEach-Object {
                         $Reader = $CA.GetDbReader($Table)
                         Get-RequestRow `
+                            -CA $CA `
                             -Reader $Reader `
                             -Property $Property `
                             -Filter "$IdColumn -eq $_" `
                             -Schema $Schema `
                             -Page $Page `
-                            -PageSize $PageSize
+                            -PageSize $PageSize `
+                            -IncludeAttribute:$IncludeAttribute `
+                            -IncludeExtension:$IncludeExtension
                     }
                 } else {
                     $Reader = $CA.GetDbReader($Table)
                     Get-RequestRow `
+                        -CA $CA `
                         -Reader $Reader `
                         -Property $Property `
                         -Filter $Filter `
                         -Schema $Schema `
                         -Page $Page `
-                        -PageSize $PageSize
+                        -PageSize $PageSize `
+                        -IncludeAttribute:$IncludeAttribute `
+                        -IncludeExtension:$IncludeExtension
                 }
             } else {
                 # 'Extension' or 'Attribute' tables may return multiple objects for single RowID. Therefore,
@@ -84,23 +92,29 @@
                         $Reader = $CA.GetDbReader($Table)
                         $LocalFilter = $Filter + "$IdColumn -eq $_"
                         Get-RequestRow `
+                            -CA $CA `
                             -Reader $Reader `
                             -Property $Property `
                             -Filter $LocalFilter `
                             -Schema $Schema `
                             -Page $Page `
-                            -PageSize $PageSize
+                            -PageSize $PageSize `
+                            -IncludeAttribute:$IncludeAttribute `
+                            -IncludeExtension:$IncludeExtension
                         #$Filter = $Filter[0..($Filter.Length - 2)]
                     }
                 } else {
                     $Reader = $CA.GetDbReader($Table)
                     Get-RequestRow `
+                        -CA $CA `
                         -Reader $Reader `
                         -Property $Property `
                         -Filter $Filter `
                         -Schema $Schema `
                         -Page $Page `
-                        -PageSize $PageSize
+                        -PageSize $PageSize `
+                        -IncludeAttribute:$IncludeAttribute `
+                        -IncludeExtension:$IncludeExtension
                 }
             }
         }

--- a/PSPKI/Server/Get-FailedRequest.ps1
+++ b/PSPKI/Server/Get-FailedRequest.ps1
@@ -16,7 +16,9 @@ function Get-FailedRequest {
         [int]$PageSize = [int]::MaxValue,
         [Alias("Properties", "IncludeProperty", "IncludeProperties", "IncludedProperty", "IncludedProperties")]
         [String[]]$Property,
-        [String[]]$Filter
+        [String[]]$Filter,
+        [switch]$IncludeAttribute,
+        [switch]$IncludeExtension
     )
     begin {
         Assert-CommandRequirement $PREREQ_RSAT -ErrorAction Stop
@@ -31,7 +33,9 @@ function Get-FailedRequest {
             -Page $Page `
             -PageSize $PageSize `
             -Property $Property `
-            -Filter $Filter
-        }        
+            -Filter $Filter `
+            -IncludeAttribute:$IncludeAttribute `
+            -IncludeExtension:$IncludeExtension
+        }
     }
 }

--- a/PSPKI/Server/Get-IssuedRequest.ps1
+++ b/PSPKI/Server/Get-IssuedRequest.ps1
@@ -16,7 +16,9 @@
         [int]$PageSize = [int]::MaxValue,
         [Alias("Properties", "IncludeProperty", "IncludeProperties", "IncludedProperty", "IncludedProperties")]
         [String[]]$Property,
-        [String[]]$Filter
+        [String[]]$Filter,
+        [switch]$IncludeAttribute,
+        [switch]$IncludeExtension
     )
     begin {
         Assert-CommandRequirement $PREREQ_RSAT -ErrorAction Stop
@@ -31,7 +33,9 @@
             -Page $Page `
             -PageSize $PageSize `
             -Property $Property `
-            -Filter $Filter
-        }        
+            -Filter $Filter `
+            -IncludeAttribute:$IncludeAttribute `
+            -IncludeExtension:$IncludeExtension
+        }
     }
 }

--- a/PSPKI/Server/Get-PendingRequest.ps1
+++ b/PSPKI/Server/Get-PendingRequest.ps1
@@ -16,7 +16,9 @@
         [int]$PageSize = [int]::MaxValue,
         [Alias("Properties", "IncludeProperty", "IncludeProperties", "IncludedProperty", "IncludedProperties")]
         [String[]]$Property,
-        [String[]]$Filter
+        [String[]]$Filter,
+        [switch]$IncludeAttribute,
+        [switch]$IncludeExtension
     )
     begin {
         Assert-CommandRequirement $PREREQ_RSAT -ErrorAction Stop
@@ -31,7 +33,9 @@
             -Page $Page `
             -PageSize $PageSize `
             -Property $Property `
-            -Filter $Filter
-        }        
+            -Filter $Filter `
+            -IncludeAttribute:$IncludeAttribute `
+            -IncludeExtension:$IncludeExtension
+        }
     }
 }

--- a/PSPKI/Server/Get-RequestRow.ps1
+++ b/PSPKI/Server/Get-RequestRow.ps1
@@ -1,15 +1,50 @@
 function Get-RequestRow {
 [CmdletBinding()]
     param(
+        [PKI.CertificateServices.CertificateAuthority]$CA,
         [SysadminsLV.PKI.Management.CertificateServices.Database.AdcsDbReader]$Reader,
         [int]$Page,
         [int]$PageSize = [int]::MaxValue,
         [String[]]$Property,
         [String[]]$Filter,
-        [SysadminsLV.PKI.Management.CertificateServices.Database.AdcsDbColumnSchema[]]$Schema
+        [SysadminsLV.PKI.Management.CertificateServices.Database.AdcsDbColumnSchema[]]$Schema,
+        [switch]$IncludeAttribute,
+        [switch]$IncludeExtension
     )
     $ErrorActionPreference = "Stop"
-# parse restriction filters
+    $AllowedIncludeSourceTables = @("Request", "Revoked", "Issued", "Pending", "Failed")
+    $AllowIncludeAttribute = $AllowedIncludeSourceTables -contains $Reader.ViewTable -and $IncludeAttribute
+    $AllowIncludeExtension = $AllowedIncludeSourceTables -contains $Reader.ViewTable -and $IncludeExtension
+
+    function Join-AttributeTable($DbRow) {
+        $NestedReader = $CA.GetDbReader("Attribute")
+        [void]$NestedReader.AddQueryFilter(
+            (New-Object SysadminsLV.PKI.Management.CertificateServices.Database.AdcsDbQueryFilter "AttributeRequestId", 1, $DbRow.Properties["RequestID"])
+        )
+        $Rows = $NestedReader.GetView() | ForEach-Object {
+            New-Object PSObject -Property @{
+                AttributeName = $_.Properties["AttributeName"]
+                AttributeValue = $_.Properties["AttributeValue"]
+            }
+        }
+        $DbRow.Properties.Add("RowAttributes", $Rows)
+    }
+    function Join-ExtensionTable($DbRow) {
+        $NestedReader = $CA.GetDbReader("Extension")
+        [void]$NestedReader.AddQueryFilter(
+            (New-Object SysadminsLV.PKI.Management.CertificateServices.Database.AdcsDbQueryFilter "ExtensionRequestId", 1, $DbRow.Properties["RequestID"])
+        )
+        $Rows = $NestedReader.GetView() | ForEach-Object {
+            New-Object PSObject -Property @{
+                ExtensionNameOid = $_.Properties["ExtensionNameOid"]
+                ExtensionObject = $_.Properties["ExtensionObject"]
+                ExtensionFlags = $_.Properties["ExtensionFlagsEnum"]
+            }
+        }
+        $DbRow.Properties.Add("RowExtensions", $Rows)
+    }
+    
+    # parse restriction filters
     if ($Filter -ne $null) {
         foreach ($line in $Filter) {
             if ($line -notmatch "^(.+)\s(-eq|-lt|-le|-ge|-gt)\s(.+)$") {
@@ -50,6 +85,13 @@ function Get-RequestRow {
     try {
         $skip = ($Page - 1) * $PageSize
         $Reader.GetView($skip, $PageSize) | ForEach-Object {
+            if ($AllowIncludeAttribute) {
+                Join-AttributeTable $_
+            }
+            if ($AllowIncludeExtension) {
+                Join-ExtensionTable $_
+            }
+
             foreach ($key in $_.Properties.Keys) {
                 $_ | Add-Member -MemberType NoteProperty $key -Value $_.Properties[$key] -Force
             }

--- a/PSPKI/Server/Get-RevokedRequest.ps1
+++ b/PSPKI/Server/Get-RevokedRequest.ps1
@@ -16,7 +16,9 @@
         [int]$PageSize = [int]::MaxValue,
         [Alias("Properties", "IncludeProperty", "IncludeProperties", "IncludedProperty", "IncludedProperties")]
         [String[]]$Property,
-        [String[]]$Filter
+        [String[]]$Filter,
+        [switch]$IncludeAttribute,
+        [switch]$IncludeExtension
     )
     begin {
         Assert-CommandRequirement $PREREQ_RSAT -ErrorAction Stop
@@ -31,7 +33,9 @@
             -Page $Page `
             -PageSize $PageSize `
             -Property $Property `
-            -Filter $Filter
-        }        
+            -Filter $Filter `
+            -IncludeAttribute:$IncludeAttribute `
+            -IncludeExtension:$IncludeExtension
+        }
     }
 }


### PR DESCRIPTION
#### PR Classification
New feature: enhances certificate database query cmdlets with options to include related attribute and extension data.

#### PR Summary
This pull request adds -IncludeAttribute and -IncludeExtension switches to several certificate database query cmdlets, enabling users to retrieve related attribute and extension data alongside main results.
- Get-AdcsDatabaseRow.ps1, Get-IssuedRequest.ps1, Get-RevokedRequest.ps1, Get-PendingRequest.ps1, and Get-FailedRequest.ps1: Add new switches and pass them to the core query logic.
- Get-RequestRow.ps1: Implements logic to join and append Attribute and Extension table data to each result row when the new switches are used.
